### PR TITLE
use commit hash to check for update

### DIFF
--- a/client6.js
+++ b/client6.js
@@ -167,11 +167,11 @@ export const PiholeClient6 = GObject.registerClass(
 
       // We assume local can never be newer than remote :)
       const newCoreAvailable =
-        json.version.core.local.version !== json.version.core.remote.version;
+        json.version.core.local.hash !== json.version.core.remote.hash;
       const newWebAvailable =
-        json.version.web.local.version !== json.version.web.remote.version;
+        json.version.web.local.hash !== json.version.web.remote.hash;
       const newFtlAvailable =
-        json.version.ftl.local.version !== json.version.ftl.remote.version;
+        json.version.ftl.local.hash !== json.version.ftl.remote.hash;
 
       this.data.updateExists =
         newCoreAvailable || newWebAvailable || newFtlAvailable;


### PR DESCRIPTION
should fix #21

as can be seen @ https://pi.hole/api/docs/#get-/info/version

```
remote: {
version: string┃null        Remote (Github) Pi-hole **** version (null if on custom branch)
hash: string┃null           Remote (Github) Pi-hole **** hash
} 
```
the hash _should_ always return a string which is the current commit for remote branch and local branch.

-----

so maybe a `hash` comparison would be better here?
https://github.com/ziyagenc/phi/blob/dfa86c9752b64b51d96946a77f08e33ce1f0d442/client6.js#L168-L174

-----

Since the assumption is made that local _can never_ be newer than remote maybe something like this would work? 
```javascript
   // We assume local can never be newer than remote :) 
   const newCoreAvailable = 
     json.version.core.local.hash !== json.version.core.remote.hash; 
   const newWebAvailable = 
     json.version.web.local.hash !== json.version.web.remote.hash; 
   const newFtlAvailable = 
     json.version.ftl.local.hash !== json.version.ftl.remote.hash;
```

-----

Pi-hole does something similar as well

https://github.com/pi-hole/pi-hole/blob/master/advanced/Scripts/update.sh#L49